### PR TITLE
Add the fail flag to curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.56.0@sha256:927125be1befca4e0f91a81a73cf1108f7552297ab8311d9fbf55b03f1c9246f
-RUN curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-11-01/rust-analyzer-x86_64-unknown-linux-gnu.gz --output rust-analyzer.gz && \
+RUN curl -sfL https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-11-01/rust-analyzer-x86_64-unknown-linux-gnu.gz --output rust-analyzer.gz && \
   gunzip rust-analyzer.gz && \
   chmod +x /rust-analyzer && \
   mv /rust-analyzer /usr/local/bin


### PR DESCRIPTION
Without the -f flag, it's possible for a curl step to succeed because
the server responded with HTML describing the error and curl wrongly
assumes it's what you want.