### PR TITLE
bump rust-analyzer and transition to uploading SCIP instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           push: true
           tags: |
-            sourcegraph/lsif-rust:latest
-            sourcegraph/lsif-rust:${{ env.PATCH }}
-            sourcegraph/lsif-rust:${{ env.MINOR }}
-            sourcegraph/lsif-rust:${{ env.MAJOR }}
+            sourcegraph/scip-rust:latest
+            sourcegraph/scip-rust:${{ env.PATCH }}
+            sourcegraph/scip-rust:${{ env.MINOR }}
+            sourcegraph/scip-rust:${{ env.MAJOR }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM rust:1.56.0@sha256:927125be1befca4e0f91a81a73cf1108f7552297ab8311d9fbf55b03f1c9246f
-RUN curl -sfL https://github.com/rust-analyzer/rust-analyzer/releases/download/2021-11-01/rust-analyzer-x86_64-unknown-linux-gnu.gz --output rust-analyzer.gz && \
+FROM rust:1.66.1@sha256:f72949bcf1daf8954c0e0ed8b7e10ac4c641608f6aa5f0ef7c172c49f35bd9b5
+
+COPY scip-rust /usr/local/bin/scip-rust
+
+RUN chmod +x /usr/local/bin/scip-rust
+
+RUN curl -sfL https://github.com/rust-analyzer/rust-analyzer/releases/download/2023-01-23/rust-analyzer-x86_64-unknown-linux-gnu.gz --output rust-analyzer.gz && \
   gunzip rust-analyzer.gz && \
   chmod +x /rust-analyzer && \
   mv /rust-analyzer /usr/local/bin
-COPY lsif-rust /usr/local/bin/lsif-rust
-RUN chmod +x /usr/local/bin/lsif-rust

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# lsif-rust
+# scip-rust
 
-At the moment, this is just a tiny wrapper around `rust-analyzer` to generate LSIF data,
+At the moment, this is just a tiny wrapper around `rust-analyzer` to generate SCIP data,
 with the configuration set up for use by Sourcegraph.
 
 If you want to upload LSIF to Sourcegraph.com in CI, check out

--- a/scip-rust
+++ b/scip-rust
@@ -10,4 +10,4 @@ set -eux
 # crates (X1, X2, Y1 and Y2). So it is enough to run rust-analyzer once,
 # instead of once per workspace, or once per crate.
 
-rust-analyzer lsif . > dump.lsif
+rust-analyzer scip . > dump.scip


### PR DESCRIPTION
We've been using a `rust-analyzer` version from 2021, which is missing important fixes such as:
https://github.com/rust-lang/rust-analyzer/pull/13296
https://github.com/rust-lang/rust-analyzer/pull/10891
https://github.com/rust-lang/rust-analyzer/pull/12976
https://github.com/rust-lang/rust-analyzer/pull/13456
https://github.com/rust-lang/rust-analyzer/pull/11793
https://github.com/rust-lang/rust-analyzer/pull/10841

and maybe one or two more max.

At the same time (or perhaps in a separate PR, but the differencein impact feels low enough in combination), it moves to using SCIP as its output format. To not be an unexpected change to existing users of `sourcegraph/lsif-rust` docker image, we push to a new more aptly named image `sourcegraph/scip-rust`. We likely want to update the name of the repo to match this.

A sister PR will be required in https://github.com/sourcegraph/sourcegraph` to use the new docker image once its published for auto-indexing. This will be fine as it will be only included in versions that can natively accept SCIP.

Theres also https://github.com/sourcegraph/lsif-rust-action, i dont know what we want to do there, but its not impacted by this repo

### Test plan

Ran `docker build` to confirm that all links etc were correct and files were as expected when unzipping
