### PR TITLE
Add container testing + fix breakage

### DIFF
--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -1,0 +1,22 @@
+name: Container Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  container-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Podman
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+    
+    - name: Run container test
+      run: ./test-container.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+scratch/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,4 @@ COPY scip-rust /usr/local/bin/scip-rust
 
 RUN chmod +x /usr/local/bin/scip-rust
 
-RUN curl -sfL https://github.com/rust-analyzer/rust-analyzer/releases/download/2023-07-03/rust-analyzer-x86_64-unknown-linux-gnu.gz --output rust-analyzer.gz && \
-  gunzip rust-analyzer.gz && \
-  chmod +x /rust-analyzer && \
-  mv /rust-analyzer /usr/local/bin
+RUN rustup component add rust-analyzer

--- a/test-container.sh
+++ b/test-container.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Starting container test...${NC}"
+
+# Create scratch directory if it doesn't exist
+if [[ ! -d "./scratch" ]]; then
+    echo -e "${YELLOW}Creating scratch directory...${NC}"
+    mkdir -p scratch
+fi
+
+# Clone or update ripgrep repo
+if [[ ! -d "./scratch/ripgrep" ]]; then
+    echo -e "${YELLOW}Cloning ripgrep repository...${NC}"
+    git clone https://github.com/BurntSushi/ripgrep.git ./scratch/ripgrep
+else
+    echo -e "${YELLOW}Updating ripgrep repository...${NC}"
+    cd ./scratch/ripgrep
+    git fetch origin
+    git reset --hard origin/master
+    cd ../..
+fi
+
+# Build the container with linux/amd64 platform
+echo -e "${YELLOW}Building container image...${NC}"
+podman build --platform=linux/amd64 -t scip-rust-test .
+
+# Run the container against the ripgrep codebase
+echo -e "${YELLOW}Running scip-rust against ripgrep codebase...${NC}"
+podman run --platform=linux/amd64 --rm -v "./scratch/ripgrep:/workspace:z" scip-rust-test \
+    /usr/local/bin/scip-rust /workspace
+
+echo -e "${GREEN}Container test completed successfully!${NC}"


### PR DESCRIPTION
When we bumped the base Rust image, we changed how the PATH
is handled. This would cause rust-analyzer from /usr/local/cargo/bin
to be found first. This was not installed by default, so it
would trigger an indexing error when trying to use 'scip-rust index'.

This patch changes the Dockerfile to use the official rust-analyzer
component (previously, it wasn't bundled). It also adds a test for
the container, so that we don't accidentally regress functionality.

Amp thread: https://ampcode.com/threads/T-a42734d9-1383-4901-8819-0bacfa7c17fa

### Test plan

See added test