### PR TITLE
Document multi-project limitation, refs #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,13 @@ If you use Nix, run it straight from the flake:
 nix run github:sourcegraph/scip-rust
 ```
 
+## Limitations
+
+`scip-rust` expects one Cargo project per run. If your repo has several
+independent crates or workspaces (or no `Cargo.toml` at the path you pass), the
+run fails. Index each project on its own and upload the results separately.
+Details in [issue #5].
+
   [`rust-analyzer`]: https://rust-analyzer.github.io/book/installation.html
   [`scip-rust`]: ./scip-rust
+  [issue #5]: https://github.com/sourcegraph/scip-rust/issues/5

--- a/scip-rust
+++ b/scip-rust
@@ -22,14 +22,6 @@ for tool in cargo rust-analyzer rustc; do
     fi
 done
 
-# rust-analyzer's path lookup looks in subdirectories by default. For example,
-# in the general case, if you have multiple parallel workspaces, under say
-# - A/B/C with crates X1, X2
-# - A/B/D with crates Y1, Y2
-# and you run rust-analyzer with A/ as the project path, it will pick up all
-# crates (X1, X2, Y1 and Y2). So it is enough to run rust-analyzer once,
-# instead of once per workspace, or once per crate.
-#
 # Forward any extra args (e.g. `--output PATH`) to rust-analyzer; default
 # to indexing the current directory if no path is given.
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
`rust-analyzer scip` requires a single project root and this wrapper makes no attempt to handle multi-workspace or no-root-manifest repos.

- Drop the misleading comment in [scip-rust](./scip-rust) that claimed rust-analyzer auto-discovers subdirectory workspaces.
- Add a short section to [README.md](./README.md) pointing at #5 so users know the failure mode and the workaround (index each project on its own and upload separately).